### PR TITLE
Backported fix for bug #1206 (no USB on STM32F103x6 MCUs)

### DIFF
--- a/os/hal/ports/STM32/STM32F1xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32F1xx/stm32_registry.h
@@ -245,6 +245,8 @@
 #define STM32_HAS_USART6                    FALSE
 #define STM32_HAS_UART7                     FALSE
 #define STM32_HAS_UART8                     FALSE
+#define STM32_HAS_UART9                     FALSE
+#define STM32_HAS_UART10                    FALSE
 #define STM32_HAS_LPUART1                   FALSE
 
 /* USB attributes.*/
@@ -430,10 +432,19 @@
 #define STM32_HAS_USART6                    FALSE
 #define STM32_HAS_UART7                     FALSE
 #define STM32_HAS_UART8                     FALSE
+#define STM32_HAS_UART9                     FALSE
+#define STM32_HAS_UART10                    FALSE
 #define STM32_HAS_LPUART1                   FALSE
 
 /* USB attributes.*/
+#if defined(STM32F103x6)
+#define STM32_HAS_USB                       TRUE
+#define STM32_USB_ACCESS_SCHEME_2x16        FALSE
+#define STM32_USB_PMA_SIZE                  512
+#define STM32_USB_HAS_BCDR                  FALSE
+#else
 #define STM32_HAS_USB                       FALSE
+#endif
 #define STM32_HAS_OTG1                      FALSE
 #define STM32_HAS_OTG2                      FALSE
 
@@ -628,13 +639,19 @@
 #define STM32_HAS_USART6                    FALSE
 #define STM32_HAS_UART7                     FALSE
 #define STM32_HAS_UART8                     FALSE
+#define STM32_HAS_UART9                     FALSE
+#define STM32_HAS_UART10                    FALSE
 #define STM32_HAS_LPUART1                   FALSE
 
 /* USB attributes.*/
+#if defined(STM32F103xB)
 #define STM32_HAS_USB                       TRUE
 #define STM32_USB_ACCESS_SCHEME_2x16        FALSE
 #define STM32_USB_PMA_SIZE                  512
 #define STM32_USB_HAS_BCDR                  FALSE
+#else
+#define STM32_HAS_USB                       FALSE
+#endif
 #define STM32_HAS_OTG1                      FALSE
 #define STM32_HAS_OTG2                      FALSE
 
@@ -868,6 +885,8 @@
 #define STM32_HAS_USART6                    FALSE
 #define STM32_HAS_UART7                     FALSE
 #define STM32_HAS_UART8                     FALSE
+#define STM32_HAS_UART9                     FALSE
+#define STM32_HAS_UART10                    FALSE
 #define STM32_HAS_LPUART1                   FALSE
 
 /* USB attributes.*/
@@ -1126,6 +1145,8 @@
 #define STM32_HAS_USART6                    FALSE
 #define STM32_HAS_UART7                     FALSE
 #define STM32_HAS_UART8                     FALSE
+#define STM32_HAS_UART9                     FALSE
+#define STM32_HAS_UART10                    FALSE
 #define STM32_HAS_LPUART1                   FALSE
 
 /* USB attributes.*/
@@ -1365,6 +1386,8 @@
 #define STM32_HAS_USART6                    FALSE
 #define STM32_HAS_UART7                     FALSE
 #define STM32_HAS_UART8                     FALSE
+#define STM32_HAS_UART9                     FALSE
+#define STM32_HAS_UART10                    FALSE
 #define STM32_HAS_LPUART1                   FALSE
 
 /* USB attributes.*/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Commits r15195 to r151987 fixed [bug 1206](https://forum.chibios.org/viewtopic.php?f=35&t=5975#p40712) that didn't enable USB on STM32F103x6 (low density) MCUs.  
Also mentioned on qmk/qmk_firmware#15297.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
